### PR TITLE
Make images suitable for Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: ci
+
+on: [push, workflow_dispatch]
+
+jobs:
+  ubuntu_ci:
+    uses: ./.github/workflows/docker_build.yml
+    with:
+      name: "ubuntu-ci"
+    permissions:
+      packages: write
+      contents: read
+
+  fedora_ci:
+    uses: ./.github/workflows/docker_build.yml
+    with:
+      name: "fedora-ci"
+    permissions:
+      packages: write
+      contents: read

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,0 +1,71 @@
+name: Publish Docker image
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        required: true
+        type: string
+
+jobs:
+  archspecific:
+    name: docker_build_archspecific
+    runs-on: ["self-hosted", "linux", "${{ matrix.arch }}"]
+    strategy:
+      matrix:
+        arch: [ARM64, X64]
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Create working directory
+        run: |
+          mkdir -p ${{ github.workspace }}/${{ github.job }}-${{ github.run_number }}
+
+      - name: Check out the repo
+        run: |
+          cd ${{ github.workspace }}/${{ github.job }}-${{ github.run_number }}
+          git clone ${{ github.server_url }}/${{ github.repository }} --branch ${{ github.ref_name }} --single-branch src
+
+      - name: Log in to the Container registry
+        run: |
+          docker login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
+
+      - name: Build and push image
+        run: |
+          cd ${{ github.workspace }}/${{ github.job }}-${{ github.run_number }}/src/${{ inputs.name }}
+          docker build -t ghcr.io/${{ github.repository }}:${{ inputs.name }}-${{ matrix.arch }} .
+          docker push ghcr.io/${{ github.repository }}:${{ inputs.name }}-${{ matrix.arch }}
+
+      - name: Cleanup working directory
+        if: always()
+        run: |
+          rm -rf ${{ github.workspace }}/${{ github.job }}-${{ github.run_number }}
+
+  multiarch:
+    name: docker_multiarch
+    needs: [archspecific]
+    runs-on: ["self-hosted", "linux"]
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Log in to the Container registry
+        run: |
+          docker login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
+
+      - name: Multiarchify
+        run: |
+          docker manifest create \
+          ghcr.io/${{ github.repository }}:${{ inputs.name }} \
+          ghcr.io/${{ github.repository }}:${{ inputs.name }}-ARM64 \
+          ghcr.io/${{ github.repository }}:${{ inputs.name }}-X64
+
+      - name: Push image
+        run: |
+          docker manifest push ghcr.io/${{ github.repository }}:${{ inputs.name }}
+
+      - name: Cleanup local manifest
+        if: always()
+        run: |
+          docker manifest rm ghcr.io/${{ github.repository }}:${{ inputs.name }}

--- a/fedora-ci/Dockerfile
+++ b/fedora-ci/Dockerfile
@@ -1,0 +1,60 @@
+ARG  FEDORA_VERSION=39
+
+FROM fedora:${FEDORA_VERSION}
+
+ARG c_compiler=clang
+ARG cxx_compiler=clang++
+ENV c_compiler=$c_compiler
+ENV cxx_compiler=$cxx_compiler
+
+# clang-plugin build dependencies:
+#  * clang-devel
+#  * llvm-devel
+RUN	dnf install -y clang compiler-rt lld cmake make pkgconf-pkg-config \
+	perl ragel file-devel glib2-devel libarchive-devel libevent-devel libicu-devel luajit-devel openssl-devel sqlite-devel zlib-devel \
+	clang-devel llvm-devel libsodium-devel ninja-build git && \
+	rm /var/log/*.log && rm -r /var/cache/dnf
+
+RUN	set -x; \
+	sysArch="$(uname -m)" && \
+	case "$sysArch" in \
+		x86_64) \
+			dnf install -y hyperscan-devel && mkdir /vectorscan ; \
+			;; \
+		aarch64) \
+			rm -fr /vectorscan-src/ /vectorscan && \
+			dnf install -y boost-devel git python3-devel sqlite-devel && \
+			git clone https://github.com/VectorCamp/vectorscan --depth 1 --branch vectorscan/5.4.11 /vectorscan-src && \
+			(cd /vectorscan-src ; mkdir build ; cd build ; cmake .. -DCMAKE_C_COMPILER="$c_compiler" -DCMAKE_CXX_COMPILER="$cxx_compiler" -DCMAKE_INSTALL_PREFIX=/vectorscan -DCMAKE_BUILD_TYPE=Release -DFAT_RUNTIME=ON -DCMAKE_C_FLAGS="-fpic -fPIC" -DCMAKE_CXX_FLAGS="-fPIC -fpic" -DPCRE_SUPPORT_LIBBZ2=OFF; make -j4 ; make install) && \
+			rm -fr /vectorscan-src/ ; \
+			;; \
+		*) \
+			;; \
+	esac
+
+RUN	set -x; \
+	sysArch="$(uname -m)" && \
+	case "$sysArch" in \
+		aarch64) \
+			dnf install -y libatomic ; \
+			;; \
+		*) \
+			;; \
+	esac
+
+RUN	dnf install -y \
+		gdb llvm \
+		file-libs glib2 libevent libicu libsodium luajit openssl-libs pcre sqlite-libs && \
+	dnf debuginfo-install -y \
+		glibc glib2 libsodium luajit && \
+	rm /var/log/*.log && rm -r /var/cache/dnf
+
+RUN	dnf install -y \
+	python3 python3-pip python3-setuptools python3-demjson python3-psutil python3-requests python3-tornado \
+	opendkim redis gdb && \
+	rm /var/log/*.log && rm -r /var/cache/dnf && \
+	pip3 install --no-cache --disable-pip-version-check --no-binary :all: robotframework
+
+RUN	useradd -G wheel -m build -p ''
+
+USER	build

--- a/ubuntu-ci/Dockerfile
+++ b/ubuntu-ci/Dockerfile
@@ -1,0 +1,45 @@
+ARG UBUNTU_VERSION=22.04
+
+FROM ubuntu:${UBUNTU_VERSION}
+
+ARG build_deps="binutils-dev cmake gcc g++ libarchive-dev libc6-dev libevent-dev libglib2.0-dev libicu-dev libluajit-5.1-dev libmagic-dev libsqlite3-dev libssl-dev libunwind-dev libsodium-dev make ninja-build pkg-config ragel"
+ARG ci_deps="git sudo"
+ARG vectorscan_deps="cmake g++ git libboost-dev libsqlite3-dev pkg-config python3-dev ragel"
+ARG test_deps="clickhouse-server gdb miltertest opendkim-tools python3-tornado redis-server"
+ARG robot_test_deps="python3 python3-pip python3-setuptools python3-demjson python3-psutil python3-requests"
+
+ARG c_compiler=gcc
+ARG cxx_compiler=g++
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN     apt-get update && \
+	dpkgArch="$(dpkg --print-architecture)" && \
+	set -x && \
+	case "$dpkgArch" in \
+		amd64) \
+			apt-get -qy --no-install-recommends install libhyperscan-dev libjemalloc-dev && mkdir /vectorscan ; \
+			;; \
+		arm64) \
+			rm -fr /vectorscan-src/ /vectorscan && \
+			apt-get -qy install $vectorscan_deps && \
+			git clone https://github.com/VectorCamp/vectorscan --depth 1 --branch vectorscan/5.4.11 /vectorscan-src && \
+			(cd /vectorscan-src ; mkdir build ; cd build ; cmake .. -DCMAKE_C_COMPILER="$c_compiler" -DCMAKE_CXX_COMPILER="$cxx_compiler" -DCMAKE_INSTALL_PREFIX=/vectorscan -DCMAKE_BUILD_TYPE=Release -DFAT_RUNTIME=ON -DCMAKE_C_FLAGS="-fpic -fPIC" -DCMAKE_CXX_FLAGS="-fPIC -fpic" -DPCRE_SUPPORT_LIBBZ2=OFF; make -j4 ; make install) && \
+			rm -fr /vectorscan-src/ ; \
+			;; \
+		*) \
+			;; \
+	esac && \
+	apt-get -qy --no-install-recommends install wget ca-certificates gpg gpg-agent && \
+	apt-get -qy --no-install-recommends install apt-transport-https ca-certificates dirmngr && \
+	apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 8919F6BD2B48D754 && \
+	echo "deb https://packages.clickhouse.com/deb stable main" | tee /etc/apt/sources.list.d/clickhouse.list && \
+	apt-get update && \
+	apt-get -qy --no-install-recommends install $build_deps $ci_deps $test_deps $robot_test_deps && \
+	apt-get -q clean && \
+	rm -rf /var/lib/apt/lists/* /var/log/apt/*.log && \
+	pip3 install --no-cache --disable-pip-version-check --no-binary :all: robotframework && \
+	useradd -G sudo -m build && \
+	passwd -d build
+
+USER build


### PR DESCRIPTION
 - Javascript actions like `actions/checkout` are broken on ARM, so we want to avoid using those & bundle tools to checkout repos / upload artifacts / whatever needed
 - Roll one big "CI" image per platform instead of build/test images so these steps don't have to be executed in separate workflows